### PR TITLE
Check for bad links when compiling the index

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,6 +88,8 @@ runs:
         --outdir="${{ inputs.out-dir }}"
         --docCmd:skip
         --index:only
+        --warningAsError:BrokenLink:on
+        --warningAsError:AmbiguousLink:on
         ${{ inputs.main-file }}
 
     - name: "Generate extra files"


### PR DESCRIPTION
Its important to make sure the links are correct, so convert broken/ambigious references to symbols be errors