### PR TITLE
Use docroot so that the docgen automatically handles setting the corr…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -118,9 +118,8 @@ runs:
           indexFile="${{ inputs.out-dir }}/${newFile/%html/idx}"
           # Build the file
           # TODO: PR for missing file, nim just gives random error about opening .txt
-          rootDir=$(readlink -e "${{ inputs.project-dir }}")
           echo "Documenting ${file}..."
-          $cmd --docroot:"${rootDir}" --out="${{ inputs.out-dir }}/${newFile}" --index:on -d:docgen $file
+          $cmd --docroot:"$(pwd)" --out="${{ inputs.out-dir }}/${newFile}" --index:on -d:docgen $file
 
           # Make the title be markupTitle so it gets rendered as a document in theindex.html
           sed -E -i $indexFile -e "s/nimTitle/markupTitle/"

--- a/action.yml
+++ b/action.yml
@@ -121,11 +121,8 @@ runs:
           rootDir=$(readlink -e "${{ inputs.project-dir }}")
           $cmd --docroot:"${rootDir}" --out="${{ inputs.out-dir }}/${newFile}" --index:on -d:docgen $file
 
-          origFile=$(basename $newFile)
-          # We need to perform a few patches to the index file.
-          # - Make the title be markupTitle so it gets rendered as a document in theindex.html
-          sed -E -i $indexFile \
-            -e "s/nimTitle/markupTitle/"
+          # Make the title be markupTitle so it gets rendered as a document in theindex.html
+          sed -E -i $indexFile -e "s/nimTitle/markupTitle/"
         done
 
     - name: "Run doc generation"

--- a/action.yml
+++ b/action.yml
@@ -122,6 +122,7 @@ runs:
           $cmd --docroot:"$(pwd)" --out="${{ inputs.out-dir }}/${newFile}" --index:on -d:docgen $file
 
           # Make the title be markupTitle so it gets rendered as a document in theindex.html
+          find
           sed -E -i $indexFile -e "s/nimTitle/markupTitle/"
         done
 

--- a/action.yml
+++ b/action.yml
@@ -118,15 +118,13 @@ runs:
           indexFile="${{ inputs.out-dir }}/${newFile/%html/idx}"
           # Build the file
           # TODO: PR for missing file, nim just gives random error about opening .txt
-          $cmd --out="${{ inputs.out-dir }}/${newFile}" --index:on -d:docgen $file
+          $cmd --docroot:"${{ inputs.project-dir}}" --out="${{ inputs.out-dir }}/${newFile}" --index:on -d:docgen $file
 
           origFile=$(basename $newFile)
           # We need to perform a few patches to the index file.
           # - Make the title be markupTitle so it gets rendered as a document in theindex.html
-          # - Fix the file path so it goes into the right subfolder
           sed -E -i $indexFile \
-            -e "s/nimTitle/markupTitle/" \
-            -e "s@${origFile}@${newFile}@g"
+            -e "s/nimTitle/markupTitle/"
         done
 
     - name: "Run doc generation"

--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
           # Build the file
           # TODO: PR for missing file, nim just gives random error about opening .txt
           echo "Documenting ${file}..."
-          $cmd --docroot:"$(pwd)" --out="${{ inputs.out-dir }}/${newFile}" --index:on -d:docgen $file
+          $cmd --docroot:"$(pwd)" --outdir="${{ inputs.out-dir }}" --index:on -d:docgen $file
 
           # Make the title be markupTitle so it gets rendered as a document in theindex.html
           find

--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,6 @@ runs:
           $cmd --docroot:"$(pwd)" --outdir="${{ inputs.out-dir }}" --index:on -d:docgen $file
 
           # Make the title be markupTitle so it gets rendered as a document in theindex.html
-          find
           sed -E -i $indexFile -e "s/nimTitle/markupTitle/"
         done
 

--- a/action.yml
+++ b/action.yml
@@ -118,7 +118,8 @@ runs:
           indexFile="${{ inputs.out-dir }}/${newFile/%html/idx}"
           # Build the file
           # TODO: PR for missing file, nim just gives random error about opening .txt
-          $cmd --docroot:"${{ inputs.project-dir}}" --out="${{ inputs.out-dir }}/${newFile}" --index:on -d:docgen $file
+          rootDir=$(basename "${{ inputs.project-dir }}")
+          $cmd --docroot:"${rootDir}" --out="${{ inputs.out-dir }}/${newFile}" --index:on -d:docgen $file
 
           origFile=$(basename $newFile)
           # We need to perform a few patches to the index file.

--- a/action.yml
+++ b/action.yml
@@ -118,7 +118,7 @@ runs:
           indexFile="${{ inputs.out-dir }}/${newFile/%html/idx}"
           # Build the file
           # TODO: PR for missing file, nim just gives random error about opening .txt
-          rootDir=$(basename "${{ inputs.project-dir }}")
+          rootDir=$(readlink -e "${{ inputs.project-dir }}")
           $cmd --docroot:"${rootDir}" --out="${{ inputs.out-dir }}/${newFile}" --index:on -d:docgen $file
 
           origFile=$(basename $newFile)

--- a/action.yml
+++ b/action.yml
@@ -119,6 +119,7 @@ runs:
           # Build the file
           # TODO: PR for missing file, nim just gives random error about opening .txt
           rootDir=$(readlink -e "${{ inputs.project-dir }}")
+          echo "Documenting ${file}..."
           $cmd --docroot:"${rootDir}" --out="${{ inputs.out-dir }}/${newFile}" --index:on -d:docgen $file
 
           # Make the title be markupTitle so it gets rendered as a document in theindex.html


### PR DESCRIPTION
Fixes #8 

Sets the `--docroot` flag so that the compiler knows the file is in a subdirectory when building. This also means the index file has the correct link without us needing to modify it