### PR TITLE
Run a `nimble dump` first to get rid of nimble prompts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,8 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Setup nim"
-        uses: jiro4989/setup-nim-action@v2
+      - name: "Setup nimble"
+        uses: nim-lang/setup-nimble-action@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/readme.md
+++ b/readme.md
@@ -38,8 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Setup nimble"
-        uses: nim-lang/setup-nimble-action@v1
+      - name: "Setup nim"
+        uses: jiro4989/setup-nim-action@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/scripts/buildDocs.sh
+++ b/scripts/buildDocs.sh
@@ -60,7 +60,7 @@ fi
 # To support `importdoc` we need to first build the
 # indexes
 if [[ $5 == "true" ]]; then
-    nimble -y doc \
+    nimble --useSystemNim -y doc \
         --project \
         --outdir=${output_dir} \
         --docCmd:skip \
@@ -83,7 +83,7 @@ if [[ $6 != "" ]]; then
         cmd="nim md2html" ;;
         *.nim)
         newFile=${file/%nim/html}
-        cmd="nimble -y doc" ;;
+        cmd="nimble --useSystemNim -y doc" ;;
         *)
         echo "Whats ${file}?"
         echo "I don't know how to render this file..."
@@ -100,7 +100,7 @@ if [[ $6 != "" ]]; then
 fi
 
 # Now build the documentation
-nimble -y doc \
+nimble --useSystemNim -y doc \
     --project \
     --outdir="${output_dir}" \
     --index:on \

--- a/scripts/buildDocs.sh
+++ b/scripts/buildDocs.sh
@@ -51,9 +51,11 @@ output_dir="$7/${version_name}"
 
 git checkout $commit
 
-# To remove the src/ prefix in the pages we add a dummy
-# .nimble file so that Nim thinks the files are root level
-touch "$nimble_srcDir/dummy.nimble"
+if [[ -n "$nimble_srcDir" ]]; then
+    # To remove the src/ prefix in the pages we add a dummy
+    # .nimble file so that Nim thinks the files are root level
+    touch "$nimble_srcDir/dummy.nimble"
+fi
 
 # To support `importdoc` we need to first build the
 # indexes

--- a/scripts/nimbleVar.sh
+++ b/scripts/nimbleVar.sh
@@ -4,8 +4,5 @@
 # Everything is prefixed with `nimble_`
 set -e
 set -o pipefail
-# Let the first run of nimble happen. This removes any prompts since logging goes over stdout
-# https://github.com/nim-lang/nimble/issues/1339
-nimble dump > /dev/null
-# Now try to parse the JSON
-nimble dump --json | jq -r 'to_entries[] | select(.value | type == "string") | "export nimble_\(.key)=\(.value | @sh)"'
+
+nimble --useSystemNim dump --json | jq -r 'to_entries[] | select(.value | type == "string") | "export nimble_\(.key)=\(.value | @sh)"'

--- a/scripts/nimbleVar.sh
+++ b/scripts/nimbleVar.sh
@@ -4,5 +4,8 @@
 # Everything is prefixed with `nimble_`
 set -e
 set -o pipefail
-
+# Let the first run of nimble happen. This removes any prompts since logging goes over stdout
+# https://github.com/nim-lang/nimble/issues/1339
+nimble dump > /dev/null
+# Now try to parse the JSON
 nimble dump --json | jq -r 'to_entries[] | select(.value | type == "string") | "export nimble_\(.key)=\(.value | @sh)"'


### PR DESCRIPTION
Ran into https://github.com/nim-lang/nimble/issues/1339 in https://github.com/ire4ever1190/nort/actions/runs/23104641397/job/67111732287

Problem looks to be that it was prompting to download nim 2.2.8 (since the CI set up devel) but that caused there to be invalid JSON.

Not the best solution, but is a patch that will work for now